### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "typescript": "3.8.3",
     "warnings-to-errors-webpack-plugin": "2.0.1",
     "webpack": "5.28.0",
-    "webpack-cli": "4.5.0",
+    "webpack-cli": "4.9.0",
     "webpack-dev-server": "3.11.2"
   },
   "dependencies": {


### PR DESCRIPTION
Updated webpack-cli to version 4.9.0 in order to fix the issue with @webpack-cli/serve version 1.6.0
The issue:
After installing the project, and running `npm start` we are getting this issue.

```
[webpack-cli] Unable to load '@webpack-cli/serve' command
[webpack-cli] TypeError: options.forEach is not a function
```
It's a known issue with version 1.6.0 of `@webpack-cli/serve`
The fix for this is to update the version of `webpack-cli` to 4.9.0