### PR TITLE
Ofear patch for storybook wb5

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -29,4 +29,7 @@ module.exports = {
 			}
 		};
 	},
+	core: {
+		builder: "webpack5"
+	}
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "@storybook/addon-actions": "6.3.0",
     "@storybook/addon-essentials": "6.3.0",
     "@storybook/addon-links": "6.3.0",
+    "@storybook/builder-webpack5": "^6.3.0",
+    "@storybook/manager-webpack5": "^6.3.0",
     "@types/cordova": "0.0.34",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",


### PR DESCRIPTION
This patch should fix the issue with multiple webpack versions
Storybook used WB4 and Harmony with WB5

After this patch, Storybook will use WB5
